### PR TITLE
Switch on String: forward `default` into each length bucket

### DIFF
--- a/src/cxxcompiler/subcompilers/Expressions.hx
+++ b/src/cxxcompiler/subcompilers/Expressions.hx
@@ -1861,7 +1861,15 @@ class Expressions extends SubCompiler {
 		result += "switch(" + generateCppForStringLength("__temp") + ") {";
 		for(length => lengthCases in lengths) {
 			result += "\n\tcase " + length + ": {\n";
-			result += compileSwitchAsIfs("__temp", eType, lengthCases, null, false).tab(2);
+			// Pass `edef` so each length-bucket's if-cascade ends with
+			// the user's default branch. Without this an input whose
+			// length matches a bucket but whose value matches no case
+			// inside it falls through with no statement executed —
+			// silently breaking `switch (s) { case "A": …; default: … }`
+			// when `s` is, say, "B" (same length as the case but not
+			// in the bucket), and tripping `-Werror=return-type` when
+			// the switch is a value position.
+			result += compileSwitchAsIfs("__temp", eType, lengthCases, edef, false).tab(2);
 			result += "\n\t\tbreak;";
 			result += "\n\t}";
 		}

--- a/test/unit_testing/tests/Switch/Main.hx
+++ b/test/unit_testing/tests/Switch/Main.hx
@@ -7,6 +7,29 @@ function assert(b: Bool) {
 	}
 }
 
+// Statement-position string switch with a default. The bucket for
+// length 1 contains both "A" and "B"; any other length-1 input
+// must hit the default.
+function stmtSwitch(s: String): String {
+	var matched = "?";
+	switch(s) {
+		case "A": matched = "A";
+		case "B": matched = "B";
+		default:  matched = "default";
+	}
+	return matched;
+}
+
+// Value-position string switch — every path must yield an `Int`,
+// otherwise the codegen trips `-Werror=return-type`.
+function valueSwitch(s: String): Int {
+	return switch(s) {
+		case "A": 1;
+		case "B": 2;
+		case _:   99;
+	}
+}
+
 enum Test {
 	One;
 	Two;
@@ -37,6 +60,18 @@ function main() {
 		case "Goodbye": assert(false);
 		case "Blablabla": assert(false);
 	}
+
+	// String switch with same-length cases + default: exercises the
+	// `compileSwitchOptimizedForStrings` length-bucketed path. Inputs
+	// matching a bucket's length but no case inside it must fall
+	// through to `default`. Wrapped in helper functions so each
+	// emits its own `__temp` (the codegen declares the temp at
+	// function scope; calling one switch then another from `main`
+	// would collide).
+	assert(stmtSwitch("C") == "default");
+	assert(stmtSwitch("A") == "A");
+	assert(valueSwitch("C") == 99);
+	assert(valueSwitch("B") == 2);
 
 	// ---
 

--- a/test/unit_testing/tests/Switch/intended/include/Main.h
+++ b/test/unit_testing/tests/Switch/intended/include/Main.h
@@ -67,6 +67,8 @@ public:
 	static int returnCode;
 
 	static void assert(bool b);
+	static std::string stmtSwitch(std::string s);
+	static int valueSwitch(std::string s);
 	static void main();
 };
 

--- a/test/unit_testing/tests/Switch/intended/src/Main.cpp
+++ b/test/unit_testing/tests/Switch/intended/src/Main.cpp
@@ -14,6 +14,54 @@ void _Main::Main_Fields_::assert(bool b) {
 	};
 }
 
+std::string _Main::Main_Fields_::stmtSwitch(std::string s) {
+	std::string matched = "?"s;
+
+	auto __temp = s;
+	switch(__temp.size()) {
+		case 1: {
+			if(__temp == "A"s) {
+				matched = "A"s;
+			} else if(__temp == "B"s) {
+				matched = "B"s;
+			} else {
+				matched = "default"s;
+			}
+			break;
+		}
+		default: {
+			matched = "default"s;
+			break;
+		}
+	};
+
+	return matched;
+}
+
+int _Main::Main_Fields_::valueSwitch(std::string s) {
+	int tempResult = 0;
+
+	auto __temp = s;
+	switch(__temp.size()) {
+		case 1: {
+			if(__temp == "A"s) {
+				tempResult = 1;
+			} else if(__temp == "B"s) {
+				tempResult = 2;
+			} else {
+				tempResult = 99;
+			}
+			break;
+		}
+		default: {
+			tempResult = 99;
+			break;
+		}
+	};
+
+	return tempResult;
+}
+
 void _Main::Main_Fields_::main() {
 	int a = 123;
 
@@ -75,6 +123,11 @@ void _Main::Main_Fields_::main() {
 		}
 		default: {}
 	};
+
+	_Main::Main_Fields_::assert(_Main::Main_Fields_::stmtSwitch("C"s) == "default"s);
+	_Main::Main_Fields_::assert(_Main::Main_Fields_::stmtSwitch("A"s) == "A"s);
+	_Main::Main_Fields_::assert(_Main::Main_Fields_::valueSwitch("C"s) == 99);
+	_Main::Main_Fields_::assert(_Main::Main_Fields_::valueSwitch("B"s) == 2);
 
 	int tempNumber = 0;
 


### PR DESCRIPTION
## Summary

`compileSwitchOptimizedForStrings` (in `src/cxxcompiler/subcompilers/Expressions.hx`) buckets cases by `String.length` and emits a `switch(__temp.size()) { case N: { /* if-cascade */ } }`. It calls `compileSwitchAsIfs` per bucket with `null` for the default expression, so the user's `default:` only ends up attached to the **outer** size-switch via `compileDefaultCase(edef)`. That fires when the input's length matches no bucket, but **not** when the length matches a bucket and the value matches no case inside it. Such inputs fall through the inner if-cascade with no statement executed — silently breaking statement-position string switches and tripping `-Werror=return-type` on value-position ones.

## Repro

```haxe
switch (ch) {           // ch is a 1-char String
    case "H": ...
    case "W": ...
    case "d": ...
    case "e": ...
    default:  return 0;  // never fires for unknown 1-char inputs
}
```

The generated C++ has `case 1: { if (__temp == "H") { ... } else if (__temp == "W") ... }` with no terminating `else`, so an input like `"X"` exits via `break;`, the size-switch finishes, and the function returns nothing.

(Caught while writing a small bitmap-font helper in a real Haxe→C++ project; the `-Werror=return-type` from gcc/clang made it surface immediately.)

## Fix

Pass `edef` into the bucketed `compileSwitchAsIfs` so each cascade ends with `else { /* user default */ }`. The outer-default emission is kept — it still covers unmatched-length inputs.

## Test plan

- [x] Two regression tests added in `test/unit_testing/tests/Switch/`:
   - statement-position switch (matches the bucket length, falls through to default)
   - value-position switch (must produce a value for unmatched same-length inputs, otherwise the C++ output trips `-Werror=return-type`)
- [x] Each is wrapped in its own helper function because the codegen declares `auto __temp = ...;` at function scope; calling two string switches from the same function would currently collide on `__temp`. That's a separate, pre-existing issue and isn't in scope here.
- [x] All 46 existing unit tests still pass (`haxe Test.hxml`).
- [x] Generated C++ for the new tests builds clean under `-Werror`.

Reviewed in our fork at https://github.com/Pign/reflaxe.CPP/pull/1 before opening here.